### PR TITLE
Update rest client to version 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
 
-gem "builder", ">= 2.1.2"
-gem "rest-client", ">= 1.6.7"
-gem "json", ">= 1.6.6"
-
+gemspec

--- a/plivo.gemspec
+++ b/plivo.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.has_rdoc = true
   s.extra_rdoc_files = ['README.md']
   s.add_dependency('builder', '>= 2.1.2')
-  s.add_dependency('rest-client', '~> 1.6', '>= 1.6.7')
+  s.add_dependency('rest-client', '~> 2.0')
   s.add_dependency('json', '~> 1.6', '>= 1.6.6')
   s.add_dependency('htmlentities', '~> 4.3', '>= 4.3.1')
   s.extensions = 'ext/mkrf_conf.rb'


### PR DESCRIPTION
Resolves #36 and includes #44

This uses version 2.0 of the rest-client gem.

It also includes the changes from @penne12 pull request #44 which specifies the gems dependencies unified in the gemspec rather than duplicate it in a seperate Gemfile.
